### PR TITLE
feat: Add a regexp option to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added the `regexp` CLI option.
+
 ## [1.0.0] - 2024-03-24
 
 ### Added

--- a/src/main/java/org/codemetrics4j/executive/CommandLineExecutive.java
+++ b/src/main/java/org/codemetrics4j/executive/CommandLineExecutive.java
@@ -13,6 +13,7 @@ import org.apache.commons.io.filefilter.NotFileFilter;
 import org.apache.commons.lang3.StringUtils;
 import org.codemetrics4j.input.FileScanner;
 import org.codemetrics4j.input.Project;
+import org.codemetrics4j.input.RegexpFilter;
 import org.codemetrics4j.output.XMLOutputter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,11 @@ public class CommandLineExecutive {
             IOFileFilter fileFilter =
                     line.hasOption("excludetests") ? new ExcludeTestsFilter(scanDir) : FileFilterUtils.trueFileFilter();
 
-            scanner.setFilter(fileFilter);
+            scanner.addFilter(fileFilter);
+
+            if (line.hasOption("regexp")) {
+                scanner.addFilter(new RegexpFilter(line.getOptionValue("regexp")));
+            }
 
             long startTime = System.currentTimeMillis();
 
@@ -96,17 +101,19 @@ public class CommandLineExecutive {
     private static Options prepareOptions() {
         Options options = new Options();
 
-        // TODO: still need a way to do excludes, regex or something.  joda has an example package I want to ignore
-
         Option help = new Option("h", "help", false, "print this message");
         Option version = new Option("v", "version", false, "print the version information and exit");
         Option excludetests = new Option("xt", "excludetests", false, "exclude test files from scanning");
-        Option output = new Option("o", "output", true, "where to save output (default is print to STDOUT");
+        Option output = new Option("o", "output", true, "where to save output (default is print to STDOUT)");
+        Option regexp = new Option(
+                "r", "regexp", true, "include only files for which the absolute path matches this expression");
 
         options.addOption(help);
         options.addOption(version);
         options.addOption(excludetests);
         options.addOption(output);
+        options.addOption(regexp);
+
         return options;
     }
 

--- a/src/main/java/org/codemetrics4j/input/FileScanner.java
+++ b/src/main/java/org/codemetrics4j/input/FileScanner.java
@@ -54,7 +54,7 @@ public class FileScanner extends Scanner {
         return project;
     }
 
-    public void setFilter(IOFileFilter filter) {
+    public void addFilter(IOFileFilter filter) {
         this.filter = FileFilterUtils.and(filter, this.filter);
     }
 

--- a/src/main/java/org/codemetrics4j/input/RegexpFilter.java
+++ b/src/main/java/org/codemetrics4j/input/RegexpFilter.java
@@ -1,0 +1,23 @@
+package org.codemetrics4j.input;
+
+import java.io.File;
+import java.util.regex.Pattern;
+import org.apache.commons.io.filefilter.IOFileFilter;
+
+public class RegexpFilter implements IOFileFilter {
+    private final Pattern pattern;
+
+    public RegexpFilter(String regexp) {
+        this.pattern = Pattern.compile(regexp);
+    }
+
+    @Override
+    public boolean accept(File file) {
+        return pattern.matcher(file.getAbsolutePath()).matches();
+    }
+
+    @Override
+    public boolean accept(File dir, String name) {
+        return pattern.matcher(new File(dir, name).getAbsolutePath()).matches();
+    }
+}

--- a/src/main/java/org/codemetrics4j/input/Scanner.java
+++ b/src/main/java/org/codemetrics4j/input/Scanner.java
@@ -13,8 +13,6 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSol
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import java.io.File;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.*;
 import java.util.regex.Matcher;
 import org.apache.commons.io.FilenameUtils;
@@ -119,7 +117,7 @@ public abstract class Scanner {
                 if (packageName.isPresent()) {
                     String packagePrefix = packageName.get().replaceAll("[.]", Matcher.quoteReplacement(File.separator))
                             + File.separator;
-                    String sourceDir = FilenameUtils.getPath(sourceFileName);
+                    String sourceDir = FilenameUtils.getFullPath(sourceFileName);
                     String baseSourceDir = sourceDir.replace(packagePrefix, "");
                     String finalSourceBaseDir = baseSourceDir.replace(".", projectPath);
                     sourceDirs.add(new File(finalSourceBaseDir));
@@ -144,9 +142,7 @@ public abstract class Scanner {
                 combinedTypeSolver.add(new JavaParserTypeSolver(sourceDir));
             } catch (IllegalStateException e) {
                 logger.warn("Unable to parse code from dir {}, ignoring\n", sourceDir);
-                StringWriter sw = new StringWriter();
-                e.printStackTrace(new PrintWriter(sw));
-                logger.warn(sw.toString());
+                logger.warn("", e);
             }
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new command line option (`regexp`) to include files based on a regular expression filter. This allows for more precise selection of files for analysis.
- **Refactor**
	- Changed method name from `setFilter` to `addFilter` in file scanning logic to better reflect its functionality.
	- Simplified handling of source directories and improved exception logging in the scanning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->